### PR TITLE
Add id validation to initialization process (#5)

### DIFF
--- a/src/Functions/Invoke-PasmInitialize.ps1
+++ b/src/Functions/Invoke-PasmInitialize.ps1
@@ -120,6 +120,20 @@ Resource:                           # required
       - ap-northeast-2
 '@
 
+            # Pattern match validation 'VpcId' and 'AssociationSubnetId'
+            if ($PSBoundParameters.ContainsKey('VpcId')) {
+                if ($vpcId -cnotmatch '^vpc-[0-9a-z]{17}$') {
+                    throw [InvalidOperationException]::new($('''{0}'' does not match a valid id pattern.' -f $vpcId))
+                }
+            }
+            if ($PSBoundParameters.ContainsKey('SubnetId')) {
+                foreach ($id in $SubnetId) {
+                    if ($id -cnotmatch '^subnet-[0-9a-z]{17}$') {
+                        throw [InvalidOperationException]::new($('''{0}'' does not match a valid id pattern.' -f $id))
+                    }
+                }
+            }
+
             # If 'VpcId' or 'SubnetId' is passed from the parameter, it will overwrite the value in the sample template            
             $isPresent_VpcId = $PSBoundParameters.ContainsKey('VpcId')
             $isPresent_SubnetId = $PSBoundParameters.ContainsKey('SubnetId')


### PR DESCRIPTION
Implemented id validation to initialization process using regular expressions.

#### Invoke-PasmInitialize.ps1

```ps1
# Pattern match validation 'VpcId' and 'AssociationSubnetId'
if ($PSBoundParameters.ContainsKey('VpcId')) {
    if ($vpcId -cnotmatch '^vpc-[0-9a-z]{17}$') {
        throw [InvalidOperationException]::new($('''{0}'' does not match a valid id pattern.' -f $vpcId))
    }
}
if ($PSBoundParameters.ContainsKey('SubnetId')) {
    foreach ($id in $SubnetId) {
        if ($id -cnotmatch '^subnet-[0-9a-z]{17}$') {
            throw [InvalidOperationException]::new($('''{0}'' does not match a valid id pattern.' -f $id))
        }
    }
}
```

#### Caution

This is only a validation using regular expressions and does not guarantee that the ID actually exists.
